### PR TITLE
Port printer monitoring to backend-agnostic printer.Printer interface

### DIFF
--- a/cmd/3dp-controller/main.go
+++ b/cmd/3dp-controller/main.go
@@ -4,6 +4,7 @@ import (
 	"3dp-controller/internal/config"
 	"3dp-controller/internal/controller"
 	"3dp-controller/internal/moonraker"
+	"3dp-controller/internal/printer"
 	"3dp-controller/internal/web"
 	"bufio"
 	"context"
@@ -74,12 +75,12 @@ func main() {
 		panic(err)
 	}
 
-	monitors := make(map[string]*moonraker.Monitor)
+	monitors := make(map[string]printer.Printer)
 
 	ctx := context.Background()
 
 	for _, p := range cfg.Printers {
-		monConfig := moonraker.MonitorConfig{
+		monConfig := printer.MonitorConfig{
 			NoPauseDuration:      cfg.NoPauseDuration,
 			ShouldPauseProgress:  cfg.ShouldPauseProgress,
 			ShouldCancelProgress: cfg.ShouldCancelProgress,

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -6,8 +6,7 @@ import Col from "react-bootstrap/Col"
 import Row from "react-bootstrap/Row"
 
 import PrinterCard from "./components/PrinterCard";
-import {convertPrinter} from "../types";
-import {MoonrakerPrinterState} from "../api";
+import {convertPrinter, PrinterState} from "../types";
 import {usePrintersQuery} from "./hooks/usePrintersQuery";
 import {PrintersAPIUrlBase} from "./printersAPIContext";
 import {getPrinterStateInfo, getPrinterStateKeyByValue} from "../utils";
@@ -24,8 +23,8 @@ function Home() {
         const data = queryData.data.map(convertPrinter);
 
         data.sort((a, b) => {
-            const aDisconnected = a.state === MoonrakerPrinterState.Disconnected;
-            const bDisconnected = b.state === MoonrakerPrinterState.Disconnected;
+            const aDisconnected = a.state === PrinterState.Disconnected;
+            const bDisconnected = b.state === PrinterState.Disconnected;
 
             if (aDisconnected && !bDisconnected) return 1;
             else if (!aDisconnected && bDisconnected) return -1;
@@ -36,13 +35,13 @@ function Home() {
     }, [queryData?.data]);
 
     const printerStat = useMemo(() => {
-        return printers.reduce<Map<MoonrakerPrinterState, number>>((prev, curr) => {
+        return printers.reduce<Map<PrinterState, number>>((prev, curr) => {
             const {state} = curr;
             const count = (prev.get(state) ?? 0) + 1;
             prev.set(state, count);
 
             return prev;
-        }, new Map<MoonrakerPrinterState, number>());
+        }, new Map<PrinterState, number>());
     }, [printers]);
 
     return (

--- a/frontend/src/app/components/PrinterCard.tsx
+++ b/frontend/src/app/components/PrinterCard.tsx
@@ -4,8 +4,7 @@ import Badge from "react-bootstrap/Badge";
 import Button from "react-bootstrap/Button"
 import Card from "react-bootstrap/Card";
 
-import {getLatestJobInfo, Printer} from "../../types";
-import {MoonrakerPrinterState} from "../../api";
+import {getLatestJobInfo, Printer, PrinterState} from "../../types";
 import {getPrinterStateInfo, secondsToDurationString} from "../../utils";
 
 type PrinterCardProps = {
@@ -23,11 +22,11 @@ function PrinterCard({printer, apiURLBase}: PrinterCardProps) {
         const info = getPrinterStateInfo(printer.state);
         let {stateText, stateColor} = info;
 
-        if (printer.state === MoonrakerPrinterState.Ready) {
-            if (printer.printerStats?.state === "complete") {
+        if (printer.state === PrinterState.Ready) {
+            if (printer.job?.status === "completed") {
                 stateText = "Complete";
                 stateColor = "success";
-            } else if (printer.printerStats?.state === "cancelled") {
+            } else if (printer.job?.status === "cancelled") {
                 stateText = "Cancelled";
             }
         }
@@ -38,10 +37,10 @@ function PrinterCard({printer, apiURLBase}: PrinterCardProps) {
             isPrinterDisconnected: info.isDisconnected,
             isPrinterInErrorState: info.isInError,
         }
-    }, [printer.state, printer.printerStats?.state]);
+    }, [printer.state, printer.job?.status]);
 
-    const sdPercent = printer.virtualSD && printer.virtualSD.isActive ?
-        (printer.virtualSD.progress * 100).toFixed(1) + "%" : undefined;
+    const sdPercent = typeof printer.job?.progress === "number" ?
+        (printer.job.progress * 100).toFixed(1) + "%" : undefined;
 
     const jobInfo = useMemo(() => {
         return getLatestJobInfo(printer);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,73 +1,49 @@
-import {max} from "@popperjs/core/lib/utils/math";
-
 import {
-    MoonrakerGCodeMetadata,
-    MoonrakerJob,
-    MoonrakerPrinterObjectPrintStats,
-    MoonrakerPrinterObjectVirtualSDCard,
-    MoonrakerPrinterState,
-    WebPrinter
+    InternalWebPrinter,
+    Model3dpControllerInternalPrinterErrorInfo,
+    Model3dpControllerInternalPrinterJob,
+    Model3dpControllerInternalPrinterPrinterState,
 } from "./api";
 import {getJobStatsColor, secondsToDurationString} from "./utils";
 
-
-export interface GCodeMetadata {
-    fileName: string;
-    estimatedTime?: number;
-    uuid: string;
-    hasThumb: boolean;
-}
-
-export function convertGCodeMetadata(gcodeMeta: MoonrakerGCodeMetadata): GCodeMetadata {
-    return {
-        fileName: gcodeMeta.filename!,
-        estimatedTime: gcodeMeta.estimated_time,
-        uuid: gcodeMeta.uuid!,
-        hasThumb: (gcodeMeta.thumbnails && gcodeMeta.thumbnails.length > 0) ?? false
-    }
-}
+export const PrinterState = Model3dpControllerInternalPrinterPrinterState;
+export type PrinterState = Model3dpControllerInternalPrinterPrinterState;
 
 export interface Job {
     jobId: string;
     status: string;
-    filename: string;
-    metadata?: GCodeMetadata;
+    name: string;
+    hasThumbnail: boolean;
+
+    progress?: number;
+    printDuration?: number;
+    totalDuration?: number;
+    estimatedRemainingSec?: number;
 }
 
-export function convertJob(job: MoonrakerJob): Job {
+export function convertJob(job: Model3dpControllerInternalPrinterJob): Job {
     return {
         jobId: job.job_id!,
         status: job.status!,
-        filename: job.filename!,
-        metadata: job.metadata ? convertGCodeMetadata(job.metadata) : undefined,
+        name: job.name!,
+        hasThumbnail: job.has_thumbnail ?? false,
+
+        progress: job.progress,
+        printDuration: job.print_duration,
+        totalDuration: job.total_duration,
+        estimatedRemainingSec: job.remaining_sec,
     }
 }
 
-export interface PrinterStats {
-    printDuration: number;
-    totalDuration: number;
-    filamentUsed: number;
-    state: string;
+export interface ErrorDetail {
+    code?: number;
+    message: string;
 }
 
-export function convertPrinterStats(printerStats: MoonrakerPrinterObjectPrintStats): PrinterStats {
+export function convertErrorDetail(errorDetail: Model3dpControllerInternalPrinterErrorInfo): ErrorDetail {
     return {
-        printDuration: printerStats.print_duration!,
-        totalDuration: printerStats.total_duration!,
-        filamentUsed: printerStats.filament_used!,
-        state: printerStats.state!,
-    }
-}
-
-export interface VirtualSD {
-    progress: number;
-    isActive: boolean;
-}
-
-export function convertVirtualSD(virtualSD: MoonrakerPrinterObjectVirtualSDCard): VirtualSD {
-    return {
-        progress: virtualSD.progress!,
-        isActive: virtualSD.is_active!,
+        code: errorDetail.code,
+        message: errorDetail.message!,
     }
 }
 
@@ -75,32 +51,32 @@ export interface Printer {
     key: string;
     name: string;
     url: string;
+    type: string;
 
     registeredJobId: string;
     allowNoRegisteredPrint: boolean;
     noPauseDuration: number;
 
-    state: MoonrakerPrinterState;
+    state: PrinterState;
     printerNotOpen: boolean;
     displayMessage?: string;
     errorMessage?: string;
     lastUpdateTime: Date;
 
-    printerStats?: PrinterStats;
-    virtualSD?: VirtualSD;
-
-    loadedFile?: GCodeMetadata;
-    latestJob?: Job;
+    job?: Job;
 }
 
-export function convertPrinter(printer: WebPrinter): Printer {
-    let displayMessage = printer.display_status?.message;
+export function convertPrinter(printer: InternalWebPrinter): Printer {
+    let displayMessage = printer.message;
     if (displayMessage?.trim() === "") displayMessage = undefined;
+
+    const errorDetail = printer.error_detail ? convertErrorDetail(printer.error_detail) : undefined;
 
     return {
         key: printer.key!,
         name: printer.name!,
         url: printer.url!,
+        type: printer.type!,
 
         registeredJobId: printer.registered_job_id ?? "",
         allowNoRegisteredPrint: printer.allow_no_register_print!,
@@ -109,14 +85,10 @@ export function convertPrinter(printer: WebPrinter): Printer {
         state: printer.state!,
         printerNotOpen: false,
         displayMessage,
-        errorMessage: printer.message,
+        errorMessage: errorDetail?.message ?? printer.message,
         lastUpdateTime: new Date(printer.last_update_time!),
 
-        printerStats: printer.printer_stats ? convertPrinterStats(printer.printer_stats) : undefined,
-        virtualSD: printer.virtual_sd_card ? convertVirtualSD(printer.virtual_sd_card) : undefined,
-
-        loadedFile: printer.loaded_file ? convertGCodeMetadata(printer.loaded_file) : undefined,
-        latestJob: printer.latest_job ? convertJob(printer.latest_job) : undefined
+        job: printer.job ? convertJob(printer.job) : undefined,
     }
 }
 
@@ -144,44 +116,33 @@ export type ActiveJobInfo = Omit<JobInfo, 'isActive'> & {
 }
 
 export function getLatestJobInfo(printer: Printer): ActiveJobInfo | JobInfo | undefined {
-    if (!printer.latestJob) return undefined;
+    const job = printer.job;
+    if (!job) return undefined;
 
-    let jobInfo: ActiveJobInfo | JobInfo = {
-        id: printer.latestJob.jobId,
-        fileName: printer.latestJob.filename,
-        status: printer.latestJob.status,
-        statusColor: getJobStatsColor(printer.latestJob.status),
+    const jobInfo: ActiveJobInfo | JobInfo = {
+        id: job.jobId,
+        fileName: job.name,
+        status: job.status,
+        statusColor: getJobStatsColor(job.status),
         isActive: false,
-        imageUrl: printer.latestJob.metadata?.hasThumb ? `/printers/${printer.key}/latest_thumb` : undefined,
+        imageUrl: job.hasThumbnail ? `/printers/${printer.key}/latest_thumb` : undefined,
     };
 
-    if (printer.loadedFile?.uuid === printer.latestJob.metadata?.uuid) {
-        const printTime = printer.printerStats ?
-            secondsToDurationString(printer.printerStats.printDuration) : undefined;
+    if (job.status === "in_progress") {
+        const printTime = typeof job.printDuration === "number" ?
+            secondsToDurationString(job.printDuration) : undefined;
 
-        const totalTime = printer.printerStats ?
-            secondsToDurationString(printer.printerStats.totalDuration) : undefined;
+        const totalTime = typeof job.totalDuration === "number" ?
+            secondsToDurationString(job.totalDuration) : undefined;
 
-        let estRemainSec: number | undefined;
-        if (printer.virtualSD) {
-            if (typeof printer.loadedFile?.estimatedTime === "number") {
-                const estimatedTime = printer.loadedFile.estimatedTime;
-                const progressTime = printer.virtualSD.progress * estimatedTime;
-                estRemainSec = estimatedTime - progressTime;
-            } else if (printer.printerStats && printer.virtualSD.progress > 0) {
-                const printDuration = printer.printerStats.printDuration;
-                let totalTime = printDuration / printer.virtualSD.progress;
-                estRemainSec = totalTime - printDuration;
-            }
-        }
-
+        let estRemainSec = job.estimatedRemainingSec;
         if (typeof estRemainSec === "number" && estRemainSec < 0) {
             estRemainSec = 0;
         }
 
-        const willPause = !printer.allowNoRegisteredPrint && jobInfo.id !== printer.registeredJobId;
-        const pauseRemainSec = printer.printerStats ?
-            max(printer.noPauseDuration - printer.printerStats.printDuration, 0) : undefined;
+        const willPause = !printer.allowNoRegisteredPrint && job.jobId !== printer.registeredJobId;
+        const pauseRemainSec = typeof job.printDuration === "number" ?
+            Math.max(printer.noPauseDuration - job.printDuration, 0) : undefined;
 
         return {
             ...jobInfo,

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,8 +1,8 @@
-import {MoonrakerPrinterState} from "./api";
+import {Model3dpControllerInternalPrinterPrinterState as PrinterState} from "./api";
 
-export function getPrinterStateKeyByValue(value: MoonrakerPrinterState): string | undefined {
-    for (const key in MoonrakerPrinterState) {
-        if (MoonrakerPrinterState[key as keyof typeof MoonrakerPrinterState] === value) {
+export function getPrinterStateKeyByValue(value: PrinterState): string | undefined {
+    for (const key in PrinterState) {
+        if (PrinterState[key as keyof typeof PrinterState] === value) {
             return key;
         }
     }
@@ -16,34 +16,30 @@ export type PrinterStateInfo = {
     isDisconnected: boolean;
 }
 
-export function getPrinterStateInfo(state: MoonrakerPrinterState): PrinterStateInfo {
-    let stateText = getPrinterStateKeyByValue(state) ?? "Unknown";
+export function getPrinterStateInfo(state: PrinterState): PrinterStateInfo {
+    const stateText = getPrinterStateKeyByValue(state) ?? "Unknown";
     let isInError: boolean = false;
     let stateColor: string;
 
     switch (state) {
-        case MoonrakerPrinterState.Ready:
+        case PrinterState.Ready:
             stateColor = "dark";
             break
-        case MoonrakerPrinterState.Printing:
+        case PrinterState.Printing:
             stateColor = "primary";
             break;
-        case MoonrakerPrinterState.Pause:
+        case PrinterState.Pause:
             stateColor = "warning";
             break;
-        case MoonrakerPrinterState.KlippyShutdown:
-        case MoonrakerPrinterState.KlippyError:
-        case MoonrakerPrinterState.KlippyDisconnected:
-        case MoonrakerPrinterState.Error:
-        case MoonrakerPrinterState.InternalError:
+        case PrinterState.Error:
+        case PrinterState.InternalError:
             stateColor = "danger";
             isInError = true;
             break;
-        case MoonrakerPrinterState.PrePrint:
-        case MoonrakerPrinterState.KlippyStartup:
+        case PrinterState.PrePrint:
             stateColor = "info";
             break
-        case MoonrakerPrinterState.Disconnected:
+        case PrinterState.Disconnected:
         default:
             stateColor = "secondary";
     }
@@ -52,7 +48,7 @@ export function getPrinterStateInfo(state: MoonrakerPrinterState): PrinterStateI
         stateColor,
         stateText,
         isInError,
-        isDisconnected: (state === MoonrakerPrinterState.Disconnected),
+        isDisconnected: (state === PrinterState.Disconnected),
     }
 }
 

--- a/internal/controller/connector.go
+++ b/internal/controller/connector.go
@@ -2,7 +2,7 @@ package controller
 
 import (
 	"3dp-controller/internal/controller/api"
-	"3dp-controller/internal/moonraker"
+	"3dp-controller/internal/printer"
 	"3dp-controller/internal/util"
 	"context"
 	"errors"
@@ -17,14 +17,14 @@ type Connector struct {
 	hubId         string
 	logger        *zap.SugaredLogger
 
-	monitors        map[string]*moonraker.Monitor
+	monitors        map[string]printer.Printer
 	controlSettings map[string]api.ControlSetting
 
 	ctx        context.Context
 	cancelFunc context.CancelFunc
 }
 
-func NewConnector(controllerUrl *url.URL, hubId string, logger *zap.SugaredLogger, monitors map[string]*moonraker.Monitor) *Connector {
+func NewConnector(controllerUrl *url.URL, hubId string, logger *zap.SugaredLogger, monitors map[string]printer.Printer) *Connector {
 	return &Connector{
 		controllerUrl:   controllerUrl,
 		hubId:           hubId,
@@ -71,13 +71,13 @@ func (c *Connector) update() {
 	var updates []api.UpdateMessage
 
 	for key, monitor := range c.monitors {
-		latestJob := monitor.LatestJob()
+		job := monitor.Job()
 
 		var jobReport api.JobReport
-		if latestJob != nil {
+		if job != nil {
 			// build jobStatus
 			var jobStatus api.ReportJobStatus
-			switch latestJob.Status {
+			switch job.Status {
 			case "in_progress":
 				jobStatus = api.ReportInProgress
 			case "completed":
@@ -88,27 +88,29 @@ func (c *Connector) update() {
 
 			// build JobReport
 			jobReport = api.JobReport{
-				Id:     latestJob.JobId,
+				Id:     job.JobId,
 				Status: jobStatus,
 
-				ContentId: latestJob.Metadata.UUID,
-				StartTime: time.UnixMilli(int64(latestJob.StartTime * 1000)),
+				ContentId: job.ContentId,
+			}
+
+			if job.StartTime != nil {
+				jobReport.StartTime = *job.StartTime
 			}
 		}
 
 		// build status
 		var status api.Status
 		switch monitor.State() {
-		case moonraker.Ready:
+		case printer.Ready:
 			status = api.StatusIdle
-		case moonraker.PrePrint, moonraker.Printing:
+		case printer.PrePrint, printer.Printing:
 			status = api.StatusRunning
-		case moonraker.Pause:
+		case printer.Pause:
 			status = api.StatusPaused
-		case moonraker.Error, moonraker.InternalError,
-			moonraker.KlippyError, moonraker.KlippyShutdown, moonraker.KlippyDisconnected:
+		case printer.Error, printer.InternalError:
 			status = api.StatusError
-		case moonraker.Disconnected:
+		case printer.Disconnected:
 			status = api.StatusDisconnected
 		default:
 			status = api.StatusUnknown

--- a/internal/moonraker/moonraker_monitor.go
+++ b/internal/moonraker/moonraker_monitor.go
@@ -94,18 +94,6 @@ func (m *Monitor) LastUpdateTime() time.Time {
 	return m.lastUpdateTime
 }
 
-func (m *Monitor) PrinterObjects() *MonitorPrinterObjects {
-	return m.printerObjects
-}
-
-func (m *Monitor) LatestJob() *Job {
-	return m.latestJob
-}
-
-func (m *Monitor) LoadedFile() *GCodeMetadata {
-	return m.loadedFile
-}
-
 func (m *Monitor) Job() *printer.Job {
 	if m.latestJob == nil {
 		return nil
@@ -138,17 +126,34 @@ func (m *Monitor) Job() *printer.Job {
 		progress := m.printerObjects.VirtualSDCard.Progress
 		j.Progress = &progress
 
-		printDuration := printer.Seconds(m.printerObjects.PrintStats.GetPrintDuration().Seconds())
+		printDurationSec := m.printerObjects.PrintStats.GetPrintDuration().Seconds()
+		printDuration := printer.Seconds(printDurationSec)
 		j.PrintDuration = &printDuration
 
 		totalDuration := printer.Seconds(m.printerObjects.PrintStats.GetTotalDuration().Seconds())
 		j.TotalDuration = &totalDuration
 
-		remaining := totalDuration - printDuration
-		if remaining < 0 {
-			remaining = 0
+		var estRemainSec float64
+		haveEstimate := false
+
+		if m.loadedFile != nil && m.loadedFile.EstimatedTime != nil {
+			estimatedTime := float64(*m.loadedFile.EstimatedTime)
+			estRemainSec = estimatedTime - float64(progress)*estimatedTime
+			haveEstimate = true
+		} else if progress > 0 {
+			totalTime := printDurationSec / float64(progress)
+			estRemainSec = totalTime - printDurationSec
+			haveEstimate = true
 		}
-		j.EstimatedRemaining = &remaining
+
+		if haveEstimate {
+			if estRemainSec < 0 {
+				estRemainSec = 0
+			}
+
+			remaining := printer.Seconds(estRemainSec)
+			j.EstimatedRemaining = &remaining
+		}
 	}
 
 	return j

--- a/internal/moonraker/moonraker_monitor.go
+++ b/internal/moonraker/moonraker_monitor.go
@@ -1,44 +1,22 @@
 package moonraker
 
 import (
+	"3dp-controller/internal/printer"
 	"3dp-controller/internal/util"
 	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
-	"text/template"
 	"time"
 
 	"go.uber.org/zap"
 )
 
-type MonitorConfig struct {
-	NoPauseDuration      time.Duration
-	ShouldPauseProgress  float32
-	ShouldCancelProgress float32
-	WillPauseMessage     *template.Template
-	PauseMessage         *template.Template
-}
-
-type PrinterState string
-
-const (
-	KlippyStartup      PrinterState = "klippy_startup"
-	KlippyShutdown     PrinterState = "klippy_shutdown"
-	KlippyError        PrinterState = "klippy_error"
-	KlippyDisconnected PrinterState = "klippy_disconnected"
-
-	Ready    PrinterState = "ready"
-	PrePrint PrinterState = "pre_print"
-	Printing PrinterState = "printing"
-	Pause    PrinterState = "pause"
-	Error    PrinterState = "error"
-
-	Disconnected  PrinterState = "disconnected"
-	Unknown       PrinterState = "unknown"
-	InternalError PrinterState = "internal_error" // Internal error
-)
+var _ printer.Printer = (*Monitor)(nil)
+var _ printer.Thumbnailer = (*Monitor)(nil)
 
 type MonitorPrinterObjects struct {
 	DisplayStatus PrinterObjectDisplayStatus
@@ -52,14 +30,15 @@ type Monitor struct {
 	printerName string
 	printerUrl  *url.URL
 	logger      *zap.SugaredLogger
-	config      MonitorConfig
+	config      printer.MonitorConfig
 
 	registeredJobId    string
 	allowNoRegPrint    bool
 	jobPausedByMonitor bool
 	lastMessage        string
 
-	state          PrinterState
+	state          printer.PrinterState
+	lastError      *printer.ErrorInfo
 	lastUpdateTime time.Time
 	printerObjects *MonitorPrinterObjects
 	hasLoadedFile  bool
@@ -79,12 +58,36 @@ func (m *Monitor) PrinterUrl() string {
 	return m.printerUrl.String()
 }
 
-func (m *Monitor) Config() MonitorConfig {
+func (m *Monitor) PrinterType() string {
+	return "moonraker"
+}
+
+func (m *Monitor) Config() printer.MonitorConfig {
 	return m.config
 }
 
-func (m *Monitor) State() PrinterState {
+func (m *Monitor) State() printer.PrinterState {
 	return m.state
+}
+
+func (m *Monitor) Message() string {
+	if m.printerObjects == nil {
+		return ""
+	}
+
+	if m.printerObjects.Webhooks.State != "ready" {
+		return m.printerObjects.Webhooks.StateMessage
+	}
+
+	return m.printerObjects.PrintStats.Message
+}
+
+func (m *Monitor) ErrorDetail() *printer.ErrorInfo {
+	if m.state != printer.Error && m.state != printer.InternalError {
+		return nil
+	}
+
+	return m.lastError
 }
 
 func (m *Monitor) LastUpdateTime() time.Time {
@@ -101,6 +104,54 @@ func (m *Monitor) LatestJob() *Job {
 
 func (m *Monitor) LoadedFile() *GCodeMetadata {
 	return m.loadedFile
+}
+
+func (m *Monitor) Job() *printer.Job {
+	if m.latestJob == nil {
+		return nil
+	}
+
+	job := m.latestJob
+
+	j := &printer.Job{
+		JobId:  job.JobId,
+		Name:   job.Filename,
+		Status: job.Status,
+	}
+
+	if job.Metadata != nil {
+		j.ContentId = job.Metadata.UUID
+		j.HasThumbnail = len(job.Metadata.Thumbnails) > 0
+	}
+
+	if job.StartTime > 0 {
+		t := time.UnixMilli(int64(job.StartTime * 1000))
+		j.StartTime = &t
+	}
+
+	if job.EndTime > 0 {
+		t := time.UnixMilli(int64(job.EndTime * 1000))
+		j.EndTime = &t
+	}
+
+	if job.Status == "in_progress" && m.printerObjects != nil {
+		progress := m.printerObjects.VirtualSDCard.Progress
+		j.Progress = &progress
+
+		printDuration := printer.Seconds(m.printerObjects.PrintStats.GetPrintDuration().Seconds())
+		j.PrintDuration = &printDuration
+
+		totalDuration := printer.Seconds(m.printerObjects.PrintStats.GetTotalDuration().Seconds())
+		j.TotalDuration = &totalDuration
+
+		remaining := totalDuration - printDuration
+		if remaining < 0 {
+			remaining = 0
+		}
+		j.EstimatedRemaining = &remaining
+	}
+
+	return j
 }
 
 func (m *Monitor) RegisteredJobId() string {
@@ -138,7 +189,7 @@ func (m *Monitor) SetAllowNoRegPrint(allowNoRegPrint bool) {
 	}
 }
 
-func NewMonitor(name string, printerURL string, config MonitorConfig, logger *zap.SugaredLogger) (*Monitor, error) {
+func NewMonitor(name string, printerURL string, config printer.MonitorConfig, logger *zap.SugaredLogger) (*Monitor, error) {
 	m := new(Monitor)
 
 	u, err := url.Parse(printerURL)
@@ -155,7 +206,7 @@ func NewMonitor(name string, printerURL string, config MonitorConfig, logger *za
 	m.allowNoRegPrint = true
 	m.jobPausedByMonitor = false
 
-	m.state = Disconnected
+	m.state = printer.Disconnected
 	m.lastUpdateTime = time.Now()
 	m.hasLoadedFile = false
 
@@ -202,7 +253,7 @@ func (m *Monitor) Start(ctx context.Context) {
 			case <-ticker2.C:
 				// Update latest job
 				go func() {
-					if m.state == Disconnected || m.state == InternalError {
+					if m.state == printer.Disconnected || m.state == printer.InternalError {
 						m.latestJob = nil
 						return
 					}
@@ -230,7 +281,7 @@ func (m *Monitor) Start(ctx context.Context) {
 
 				// Update loaded file
 				go func() {
-					if m.state == Disconnected || m.state == InternalError {
+					if m.state == printer.Disconnected || m.state == printer.InternalError {
 						m.loadedFile = nil
 						return
 					}
@@ -271,28 +322,38 @@ func (m *Monitor) update() {
 
 		var nonOkErr ERRRespNotOk
 		if util.IsErrNetworkProblem(err) {
-			m.state = Disconnected
+			m.state = printer.Disconnected
+			m.lastError = nil
 		} else if errors.As(err, &nonOkErr) {
 			if nonOkErr.RespStatusCode() == 502 {
-				m.state = Disconnected
+				m.state = printer.Disconnected
+				m.lastError = nil
 			} else {
-				m.state = InternalError
+				m.state = printer.InternalError
+				code := nonOkErr.RespStatusCode()
+				m.lastError = &printer.ErrorInfo{Code: &code, Message: err.Error()}
 				m.logger.Warnf(
 					"Failed to get printer objects: %s, status_code: %d\n", err, nonOkErr.RespStatusCode(),
 				)
 			}
 		} else {
-			m.state = InternalError
+			m.state = printer.InternalError
+			m.lastError = &printer.ErrorInfo{Message: err.Error()}
 			m.logger.Errorf("Error getting printer objects: %s\n", err)
 		}
 	} else {
 		if printerObjectsResponse.Result.Status == nil {
-			m.state = Error
+			m.state = printer.Error
 			m.hasLoadedFile = false
+
+			code := printerObjectsResponse.Error.Code
+			m.lastError = &printer.ErrorInfo{Code: &code, Message: printerObjectsResponse.Error.Message}
 
 			m.logger.Errorf("MoonrakerError: %d %s\n",
 				printerObjectsResponse.Error.Code, printerObjectsResponse.Error.Message)
 		} else {
+			m.lastError = nil
+
 			status := printerObjectsResponse.Result.Status
 
 			printerObjects := new(MonitorPrinterObjects)
@@ -309,15 +370,11 @@ func (m *Monitor) update() {
 
 				switch status.Webhooks.State {
 				case "startup":
-					m.state = KlippyStartup
-				case "shutdown":
-					m.state = KlippyShutdown
-				case "error":
-					m.state = KlippyError
-				case "disconnected":
-					m.state = KlippyDisconnected
+					m.state = printer.Unknown
+				case "shutdown", "error", "disconnected":
+					m.state = printer.Error
 				default:
-					m.state = Unknown
+					m.state = printer.Unknown
 				}
 			} else {
 				printerShouldPrint := m.allowNoRegPrint || m.registeredJobId != ""
@@ -325,26 +382,26 @@ func (m *Monitor) update() {
 
 				switch printerObjects.PrintStats.State {
 				case "standby", "complete", "cancelled":
-					m.state = Ready
+					m.state = printer.Ready
 				case "printing":
 					if printDuration > 0 {
-						m.state = Printing
+						m.state = printer.Printing
 					} else {
-						m.state = PrePrint
+						m.state = printer.PrePrint
 					}
 				case "paused":
-					m.state = Pause
+					m.state = printer.Pause
 				case "error":
-					m.state = Error
+					m.state = printer.Error
 				default:
-					m.state = Unknown
+					m.state = printer.Unknown
 				}
 
 				m.hasLoadedFile = printerObjects.PrintStats.State != "standby" &&
-					m.state != Error && m.state != Unknown
+					m.state != printer.Error && m.state != printer.Unknown
 
 				// Check if printer is illegally printing
-				if m.state == Printing && !printerShouldPrint {
+				if m.state == printer.Printing && !printerShouldPrint {
 					m.logger.Infoln("Printer should not print now!!")
 
 					progress := printerObjects.VirtualSDCard.Progress
@@ -355,7 +412,7 @@ func (m *Monitor) update() {
 					}
 
 					if m.config.ShouldCancelProgress > 0 && progress >= m.config.ShouldCancelProgress {
-						if m.state == Printing {
+						if m.state == printer.Printing {
 							m.logger.Infoln("Canceling")
 							err := CancelPrint(m.ctx)
 							if err != nil {
@@ -366,7 +423,7 @@ func (m *Monitor) update() {
 				}
 
 				// Pause printer if printer should be paused by monitor
-				if m.state == Printing && m.jobPausedByMonitor {
+				if m.state == printer.Printing && m.jobPausedByMonitor {
 					m.logger.Infoln("Pausing")
 
 					err := PausePrint(m.ctx)
@@ -389,7 +446,7 @@ func (m *Monitor) update() {
 				}
 
 				// Show warning countdown if printer will be paused
-				if m.state == Printing && !m.jobPausedByMonitor && !printerShouldPrint {
+				if m.state == printer.Printing && !m.jobPausedByMonitor && !printerShouldPrint {
 					remDuration := (m.config.NoPauseDuration - printDuration).Round(time.Second)
 
 					data := struct {
@@ -412,7 +469,7 @@ func (m *Monitor) update() {
 				// Resume print if allow print set to true
 				if m.jobPausedByMonitor && printerShouldPrint {
 
-					if m.state == Pause {
+					if m.state == printer.Pause {
 						m.logger.Infoln("Resuming")
 
 						err := ResumePrint(m.ctx)
@@ -484,4 +541,31 @@ func (m *Monitor) getLoadedFile(ctx context.Context) (*GCodeMetadata, error) {
 	}
 
 	return metaResponse.Result, nil
+}
+
+func (m *Monitor) LatestThumbnail(ctx context.Context, w io.Writer) (string, error) {
+	if m.latestJob == nil || m.latestJob.Metadata == nil || len(m.latestJob.Metadata.Thumbnails) == 0 {
+		return "", printer.ErrNoThumbnail
+	}
+
+	thumb := m.latestJob.Metadata.Thumbnails[len(m.latestJob.Metadata.Thumbnails)-1]
+
+	u := m.printerUrl.JoinPath("/server/files/gcodes").JoinPath(thumb.RelativePath)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		return "", err
+	}
+
+	return resp.Header.Get("Content-Type"), nil
 }

--- a/internal/moonraker/moonraker_monitor.go
+++ b/internal/moonraker/moonraker_monitor.go
@@ -122,7 +122,10 @@ func (m *Monitor) Job() *printer.Job {
 		j.EndTime = &t
 	}
 
-	if job.Status == "in_progress" && m.printerObjects != nil {
+	loadedFileMatchesJob := m.loadedFile != nil && job.Metadata != nil &&
+		m.loadedFile.UUID == job.Metadata.UUID
+
+	if job.Status == "in_progress" && m.printerObjects != nil && loadedFileMatchesJob {
 		progress := m.printerObjects.VirtualSDCard.Progress
 		j.Progress = &progress
 

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -1,0 +1,90 @@
+package printer
+
+import (
+	"context"
+	"errors"
+	"io"
+	"text/template"
+	"time"
+)
+
+// PrinterState is the backend-agnostic state of a printer.
+type PrinterState string
+
+const (
+	Ready    PrinterState = "ready"
+	PrePrint PrinterState = "pre_print"
+	Printing PrinterState = "printing"
+	Pause    PrinterState = "pause"
+	Error    PrinterState = "error"
+
+	Disconnected  PrinterState = "disconnected"
+	Unknown       PrinterState = "unknown"
+	InternalError PrinterState = "internal_error" // Internal error
+)
+
+// MonitorConfig holds the job-authorization enforcement policy shared by every
+// backend.
+type MonitorConfig struct {
+	NoPauseDuration      time.Duration
+	ShouldPauseProgress  float32
+	ShouldCancelProgress float32
+	WillPauseMessage     *template.Template
+	PauseMessage         *template.Template
+}
+
+// Printer is the backend-agnostic contract implemented by every printer
+// backend (moonraker.Monitor, bambu.Monitor). The web, controller and main
+// packages depend only on this interface.
+type Printer interface {
+	// Identity / config
+	PrinterName() string
+	PrinterUrl() string
+	PrinterType() string
+	Config() MonitorConfig
+
+	// Observed state (read by web + controller)
+	State() PrinterState
+	Message() string
+	// ErrorDetail is non-nil only while State() is Error or InternalError and
+	// the backend has something to report (a code and/or message beyond what
+	// Message() already carries).
+	ErrorDetail() *ErrorInfo
+	LastUpdateTime() time.Time
+	Job() *Job
+
+	// Authorization state
+	RegisteredJobId() string
+	AllowNoRegPrint() bool
+	JobPausedByMonitor() bool
+
+	// Commands
+	SetRegisteredJobId(jobId string)
+	SetAllowNoRegPrint(allow bool)
+
+	// Lifecycle
+	Start(ctx context.Context)
+	Stop()
+}
+
+// ErrNoThumbnail is returned by Thumbnailer.LatestThumbnail when no thumbnail
+// is available for the latest job.
+var ErrNoThumbnail = errors.New("no thumbnail available")
+
+// Thumbnailer is an optional capability. Backends that can serve the latest
+// job's thumbnail implement it; the web layer type-asserts for it and returns
+// 501/404 when a backend does not.
+type Thumbnailer interface {
+	// LatestThumbnail writes the thumbnail image bytes to w and returns the
+	// content type. It returns ErrNoThumbnail when none is available.
+	LatestThumbnail(ctx context.Context, w io.Writer) (contentType string, err error)
+}
+
+// RawReporter is an optional capability for backends that can expose their
+// raw wire-level report state verbatim (e.g. Bambu's merged MQTT print
+// report), beyond what the neutral Printer DTO carries. The returned value
+// must be JSON-marshalable; the web layer type-asserts for it and returns
+// 501 when a backend does not implement it.
+type RawReporter interface {
+	RawReport() any
+}

--- a/internal/printer/types.go
+++ b/internal/printer/types.go
@@ -1,0 +1,65 @@
+package printer
+
+import "time"
+
+// This file holds the neutral data-transfer types shared by all printer
+// backends and consumed by the web and controller layers. Each backend
+// (moonraker, bambu) computes these from its own wire format; neither
+// backend's raw shape leaks through here. They also double as the web API's
+// JSON DTOs (json tags below) — internal/web references them directly rather
+// than redefining near-duplicate copies.
+
+// Seconds is a duration expressed in (fractional) seconds for JSON. swag
+// (this project's OpenAPI generator) reads a field's Go type statically to
+// build the schema, so a plain time.Duration would be described as its
+// default JSON encoding (raw nanoseconds) — wrong, since callers want
+// seconds. Construct with Seconds(d.Seconds()).
+type Seconds float64
+
+// ErrorInfo describes a backend's error state in more detail than
+// PrinterState.Error/InternalError alone conveys. Code is a backend-specific
+// raw code, nil when the backend has none available — there's no
+// cross-vendor decoding of it (e.g. Bambu's print_error/hms codes are
+// undocumented). Message is human-readable text when the backend has any;
+// may be empty. Unrelated to Printer.Message(), which is a general
+// status/display-text concept, not specifically about errors.
+type ErrorInfo struct {
+	Code    *int   `json:"code"`
+	Message string `json:"message"`
+}
+
+// Job is the neutral representation of a print job, returned by
+// Printer.Job(). It's non-nil once any job has been observed.
+// Progress/PrintDuration/TotalDuration/EstimatedRemaining are non-nil only
+// while that job is actively pre-printing/printing/paused — nil once it's no
+// longer active, since they're meaningless at that point. The
+// identity/outcome fields below are always populated once a job exists,
+// whether or not it's still active.
+type Job struct {
+	JobId        string `json:"job_id"`
+	Name         string `json:"name"`
+	HasThumbnail bool   `json:"has_thumbnail"`
+
+	// Identity/outcome — always populated once a job exists.
+	Status string `json:"status"` // "in_progress" | "completed" | "cancelled" | "interrupted" | "error" | "quit" | ...
+	// StartTime/EndTime are nil when a backend genuinely doesn't know them
+	// (e.g. EndTime while a job is still in progress) — not fabricated as a
+	// zero time.
+	StartTime *time.Time `json:"start_time"`
+	EndTime   *time.Time `json:"end_time"`
+	// ContentId is an opaque content identifier (e.g. Moonraker's
+	// slicer-computed file UUID); empty when the backend has no such concept.
+	// Do not repurpose this for anything else (display titles, etc.).
+	ContentId string `json:"content_id"`
+
+	// Live progress — non-nil only while the job is active. Nil when a
+	// backend genuinely doesn't know a value — not every printer
+	// model/vendor exposes the same information, so callers must handle
+	// absence rather than receiving a fabricated value.
+	Progress      *float32 `json:"progress"` // 0..1, unified across vendors
+	PrintDuration *Seconds `json:"print_duration"`
+	// TotalDuration is best-effort; it may equal PrintDuration if no better
+	// estimate exists.
+	TotalDuration      *Seconds `json:"total_duration"`
+	EstimatedRemaining *Seconds `json:"remaining_sec"`
+}

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -1,12 +1,13 @@
 package web
 
 import (
-	"3dp-controller/internal/moonraker"
+	"3dp-controller/internal/printer"
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strconv"
 	"time"
 
@@ -80,45 +81,23 @@ type UpdatePrinterResponse struct {
 	AllowNoRegPrint *bool   `json:"allow_no_reg_print"`
 }
 
-func makePrinter(key string, m *moonraker.Monitor) Printer {
-	printerObjs := m.PrinterObjects()
-
-	var message string
-	var printerStats *moonraker.PrinterObjectPrintStats
-	var displayStatus *moonraker.PrinterObjectDisplayStatus
-	var virtualSDCard *moonraker.PrinterObjectVirtualSDCard
-
-	if printerObjs != nil {
-		if printerObjs.Webhooks.State != "ready" {
-			message = printerObjs.Webhooks.StateMessage
-		} else {
-			message = printerObjs.PrintStats.Message
-		}
-
-		printerStats = &printerObjs.PrintStats
-		displayStatus = &printerObjs.DisplayStatus
-		virtualSDCard = &printerObjs.VirtualSDCard
-	}
-
+func makePrinter(key string, p printer.Printer) Printer {
 	return Printer{
 		Key:  key,
-		Name: m.PrinterName(),
-		Url:  m.PrinterUrl(),
+		Name: p.PrinterName(),
+		Url:  p.PrinterUrl(),
+		Type: p.PrinterType(),
 
-		RegJobId:        m.RegisteredJobId(),
-		AllowNoRegPrint: m.AllowNoRegPrint(),
-		NoPauseDuration: m.Config().NoPauseDuration.Seconds(),
+		RegJobId:        p.RegisteredJobId(),
+		AllowNoRegPrint: p.AllowNoRegPrint(),
+		NoPauseDuration: p.Config().NoPauseDuration.Seconds(),
 
-		State:          m.State(),
-		Message:        message,
-		LastUpdateTime: m.LastUpdateTime().UnixMilli(),
+		State:          p.State(),
+		Message:        p.Message(),
+		ErrorDetail:    p.ErrorDetail(),
+		LastUpdateTime: p.LastUpdateTime().UnixMilli(),
 
-		PrinterStats:  printerStats,
-		DisplayStatus: displayStatus,
-		VirtualSDCard: virtualSDCard,
-
-		LoadedFile: m.LoadedFile(),
-		LatestJob:  m.LatestJob(),
+		Job: p.Job(),
 	}
 }
 
@@ -186,64 +165,46 @@ func (s *Server) UpdatePrinter(g *gin.Context) {
 func (s *Server) GetLatestThumbnail(g *gin.Context) {
 	printerKey := g.Param("key")
 
-	if m, ok := s.monitors[printerKey]; ok {
-		latestJob := m.LatestJob()
-		if latestJob == nil {
-			resp := APIErrorResp{
-				Error: "no latest job",
-			}
-			g.JSON(http.StatusNotFound, resp)
-			return
-		}
-
-		if len(latestJob.Metadata.Thumbnails) == 0 {
-			resp := APIErrorResp{
-				Error: "no thumbnails",
-			}
-			g.JSON(http.StatusNotFound, resp)
-			return
-		}
-
-		thumb := latestJob.Metadata.Thumbnails[len(latestJob.Metadata.Thumbnails)-1]
-
-		u, err := url.Parse(m.PrinterUrl())
-		if err != nil {
-			s.logger.Errorf("url parse error: %s", err.Error())
-			g.Status(http.StatusInternalServerError)
-			return
-		}
-
-		u = u.JoinPath("/server/files/gcodes").JoinPath(thumb.RelativePath)
-
-		ctx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
-		defer cancel()
-		req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
-		if err != nil {
-			s.logger.Errorf("create request error: %s", err.Error())
-			g.Status(http.StatusInternalServerError)
-			return
-		}
-
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			s.logger.Errorf("request error: %s", err.Error())
-			g.Status(http.StatusInternalServerError)
-			return
-		}
-
-		defer resp.Body.Close()
-
-		g.Status(http.StatusOK)
-		g.Header("Context-Length", fmt.Sprintf("%d", resp.ContentLength))
-		g.Header("Content-Type", resp.Header.Get("Content-Type"))
-
-		if _, err = io.Copy(g.Writer, resp.Body); err != nil {
-			s.logger.Errorf("copy error: %s", err.Error())
-		}
-	} else {
+	p, ok := s.monitors[printerKey]
+	if !ok {
 		resp := APIErrorResp{
 			Error: "printer not found",
 		}
 		g.JSON(http.StatusNotFound, resp)
+		return
+	}
+
+	t, ok := p.(printer.Thumbnailer)
+	if !ok {
+		resp := APIErrorResp{
+			Error: "thumbnails not supported by this printer",
+		}
+		g.JSON(http.StatusNotImplemented, resp)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
+	defer cancel()
+
+	var buf bytes.Buffer
+	contentType, err := t.LatestThumbnail(ctx, &buf)
+	if errors.Is(err, printer.ErrNoThumbnail) {
+		resp := APIErrorResp{
+			Error: "no thumbnail available",
+		}
+		g.JSON(http.StatusNotFound, resp)
+		return
+	} else if err != nil {
+		s.logger.Errorf("get latest thumbnail error: %s", err.Error())
+		g.Status(http.StatusInternalServerError)
+		return
+	}
+
+	g.Status(http.StatusOK)
+	g.Header("Content-Length", fmt.Sprintf("%d", buf.Len()))
+	g.Header("Content-Type", contentType)
+
+	if _, err := io.Copy(g.Writer, &buf); err != nil {
+		s.logger.Errorf("copy error: %s", err.Error())
 	}
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -2,7 +2,7 @@ package web
 
 import (
 	"3dp-controller/docs"
-	"3dp-controller/internal/moonraker"
+	"3dp-controller/internal/printer"
 	"context"
 	"errors"
 	"net/http"
@@ -22,12 +22,12 @@ type Server struct {
 	logger *zap.SugaredLogger
 	srv    *http.Server
 
-	monitors map[string]*moonraker.Monitor
+	monitors map[string]printer.Printer
 
 	ctx context.Context
 }
 
-func NewServer(ctx context.Context, isDevMode bool, logger *zap.SugaredLogger, monitors map[string]*moonraker.Monitor) *Server {
+func NewServer(ctx context.Context, isDevMode bool, logger *zap.SugaredLogger, monitors map[string]printer.Printer) *Server {
 	var engine *gin.Engine
 
 	if !isDevMode {

--- a/internal/web/types.go
+++ b/internal/web/types.go
@@ -1,6 +1,6 @@
 package web
 
-import "3dp-controller/internal/moonraker"
+import "3dp-controller/internal/printer"
 
 type APIErrorResp struct {
 	Error string `json:"error"`
@@ -10,19 +10,16 @@ type Printer struct {
 	Key  string `json:"key"`
 	Name string `json:"name"`
 	Url  string `json:"url"`
+	Type string `json:"type"`
 
 	RegJobId        string  `json:"registered_job_id"`
 	AllowNoRegPrint bool    `json:"allow_no_register_print"`
 	NoPauseDuration float64 `json:"no_pause_duration"`
 
-	State          moonraker.PrinterState `json:"state"`
-	Message        string                 `json:"message"`
-	LastUpdateTime int64                  `json:"last_update_time"`
+	State          printer.PrinterState `json:"state"`
+	Message        string               `json:"message"`
+	ErrorDetail    *printer.ErrorInfo   `json:"error_detail"`
+	LastUpdateTime int64                `json:"last_update_time"`
 
-	DisplayStatus *moonraker.PrinterObjectDisplayStatus `json:"display_status"`
-	PrinterStats  *moonraker.PrinterObjectPrintStats    `json:"printer_stats"`
-	VirtualSDCard *moonraker.PrinterObjectVirtualSDCard `json:"virtual_sd_card"`
-
-	LoadedFile *moonraker.GCodeMetadata `json:"loaded_file"`
-	LatestJob  *moonraker.Job           `json:"latest_job"`
+	Job *printer.Job `json:"job"`
 }


### PR DESCRIPTION
## Summary
- Make `moonraker.Monitor` implement the new `internal/printer.Printer` (and `printer.Thumbnailer`) interface, dropping its duplicate `PrinterState`/`MonitorConfig` types in favor of the shared ones.
- Switch `main.go`, `internal/web`, and `internal/controller` to depend on `map[string]printer.Printer` instead of the concrete `*moonraker.Monitor`, so a future second backend can be added without touching these layers.
- Rework the web API's `Printer` DTO to embed the neutral `printer.Job`/`printer.PrinterState`/`printer.ErrorInfo` types instead of Moonraker-raw structs; regenerate Swagger/OpenAPI + the frontend axios client accordingly.
- Update `frontend/src/types.ts`, `utils.ts`, `PrinterCard.tsx`, `App.tsx` to match the new DTO shape (drops the `loadedFile`/`latestJob` UUID-matching hack in favor of `job.status === "in_progress"`).

## Test plan
- [x] `go build ./...` and `go vet ./...`
- [x] `npx tsc -b && vite build` in `frontend/`
- [x] `npm run lint` in `frontend/` (only pre-existing generated-client warnings remain)
- [ ] Manual smoke test of `/api/v1/printers` and the dashboard against a live printer (blocked locally by another dev server already bound to :8080)

🤖 Generated with [Claude Code](https://claude.com/claude-code)